### PR TITLE
fixed build - dev tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Supported architectures are:
 
 Available Tags:
 
-- `latest`: Always points to the latest version published using OZW 1.6
+- `latest`: Always points to the latest stable version published (using OZW 1.6)
+- `dev`:  Always point to latest OZW and Zwave2Mqtt master branches
 - `latest-dev`: **DEPRECATED** Starting from version 2.1.1 OZW 1.4 is no more supported so `latest` tag will always contain OZW 1.6. Last available `latest-dev` manifest is running z2m 2.1.0 with ozw 1.6
 - `3.0.3`: OZW 1.6.1080
 - `3.0.2`: OZW 1.6.1061

--- a/bin/buildx.sh
+++ b/bin/buildx.sh
@@ -2,9 +2,19 @@ wget -O package.json https://raw.githubusercontent.com/OpenZWave/Zwave2Mqtt/mast
 VERSION=$(node -p "require('./package.json').version")
 rm package.json
 
+DOCKER_TAGS=($(wget -q https://registry.hub.docker.com/v1/repositories/robertslando/zwave2mqtt/tags -O -  | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}'))
+
+# always build dev tag
+TAGS="-t robertslando/zwave2mqtt:dev"
+
+# check if there is an image with this version, if not create new tags latest and $VERSION
+if [[ " ${DOCKER_TAGS[@]} " =~ " ${VERSION} " ]]; then 
+    TAGS="$TAGS -t robertslando/zwave2mqtt:latest -t robertslando/zwave2mqtt:$VERSION" # make a new release
+fi
+
 docker buildx build \
       --platform linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/386 \
       --file ../Dockerfile \
       --push \
-      -t robertslando/zwave2mqtt:latest -t "robertslando/zwave2mqtt:$VERSION" \
+      $TAGS \
       ../


### PR DESCRIPTION
@chrisns Please take a look to this. 

With this PR now we introduce a `dev` branch that will always point to OZW master branch.

Once the build is triggered it will check available docker tags on docker hub and if latest version is not builded this will also create a new tag with that version and update latest tag too

If it's ok for you I will move forward to:

1. Make a new 3.0.4 release on Zwave2Mqtt and trigger a build here
2. Once the release is ended, merge my PR https://github.com/OpenZWave/Zwave2Mqtt/pull/417 and yours https://github.com/OpenZWave/Zwave2Mqtt/pull/432
3. Make a new minor 3.1.0 and trigger a new build here
